### PR TITLE
Use tempname for file handles

### DIFF
--- a/src/complete_datasignature.ado
+++ b/src/complete_datasignature.ado
@@ -1,5 +1,5 @@
-*! version 3.0.0  May 17 2022  statacons team
-* Copyright 2022. This work is licensed under a CC BY 4.0 license.
+*! version 3.0.1  Apr 13 2023  statacons team
+* Copyright 2023. This work is licensed under a CC BY 4.0 license.
 version 16.1
 
 // markdown source for help file is embedded below code
@@ -16,56 +16,58 @@ if "`meta'"!="nometa" {
     //can't use log because that has timestamp, so write out to file
     tempfile meta_fname
 	*loc meta_fname meta_fname
-    qui file open meta_handle using "`meta_fname'", write text replace
+    tempname meta_handle
+    qui file open `meta_handle' using "`meta_fname'", write text replace
 
     //value labels. Do seprately from vars as some might not be attached to variables and some might be attached to multiple
     qui label dir
     loc val_labels `r(names)'
     foreach vl_name in `val_labels' {
-        file write meta_handle "`vl_name'" _newline
+        file write `meta_handle' "`vl_name'" _newline
         loc vl_len : label `vl_name' maxlength
-        file write meta_handle "`vl_len'" _newline
+        file write `meta_handle' "`vl_len'" _newline
         forv i = 1/`vl_len' {
-            file write meta_handle "`i': `: label `vl_name' `i', strict'" _newline //strict means if no value return "" rather than `i'
+            file write `meta_handle' "`i': `: label `vl_name' `i', strict'" _newline //strict means if no value return "" rather than `i'
         }
     }
 
     //variable formats, labels, and value label attachments
     foreach v of varlist * {
-        file write meta_handle "`v'" _newline
-        file write meta_handle "`: format `v''" _newline
-        file write meta_handle "`: variable label `v''" _newline
-        file write meta_handle "`: value label `v''" _newline
+        file write `meta_handle' "`v'" _newline
+        file write `meta_handle' "`: format `v''" _newline
+        file write `meta_handle' "`: variable label `v''" _newline
+        file write `meta_handle' "`: value label `v''" _newline
     }
 
     if "`labels_formats_only'"=="" {
         //don't use describe as that prints timestamp
-        file write meta_handle "`: data label'" _newline
+        file write `meta_handle' "`: data label'" _newline
 
         //chars: includes notes
         //can't use -char dir- as it only prints to screen
         unab vlist : *
         loc evlist _dta `vlist'
         foreach ev in `evlist' {
-            file write meta_handle "`ev'" _newline
+            file write `meta_handle' "`ev'" _newline
             loc c_list : char `ev'[]
             foreach c in `c_list' {
-                file write meta_handle "`c': `: char `ev'[`c']'" _newline
+                file write `meta_handle' "`c': `: char `ev'[`c']'" _newline
             }
         }
     }
     
     //could add the sortlist: -describe, varlist; r(sortlist)-
 
-    file close meta_handle
+    file close `meta_handle'
     qui checksum "`meta_fname'"
     loc meta_sig ":`r(checksum)'"
 }
 
 if "`fname'"!="" {
-    file open sig_handle using "`fname'", write text replace
-    file write sig_handle "`datasig'`meta_sig'"
-    file close sig_handle
+    tempname sig_handle
+    file open `sig_handle' using "`fname'", write text replace
+    file write `sig_handle' "`datasig'`meta_sig'"
+    file close `sig_handle'
 }
 di "`datasig'`meta_sig'"
 return local signature "`datasig'`meta_sig'"


### PR DESCRIPTION
Using a tempname as the file handle eliminates a bug where a file handle is left open when code crashes after the file is opened but before the file is closed. For example, in published version 3.0.0:

```
. clear all

. complete_datasignature, fast
variable * not found
r(111);

. sysuse auto
(1978 automobile data)

. complete_datasignature, fast
file handle meta_handle already exists
r(110);
```

In this bugfix branch:

```
. clear all

. complete_datasignature, fast
variable * not found
r(111);

. sysuse auto
(1978 automobile data)

. complete_datasignature, fast
74:12(71728):3831085005:186045760:3824887947
```