### PR TITLE
Fix datasignature bug: ensure invariance to ordering of char

### DIFF
--- a/src/complete_datasignature.ado
+++ b/src/complete_datasignature.ado
@@ -49,7 +49,7 @@ if "`meta'"!="nometa" {
         foreach ev in `evlist' {
             file write meta_handle "`ev'" _newline
             loc c_list : char `ev'[]
-            foreach c in `c_list' {
+            foreach c in `: list sort c_list' {
                 file write meta_handle "`c': `: char `ev'[`c']'" _newline
             }
         }

--- a/src/complete_datasignature.ado
+++ b/src/complete_datasignature.ado
@@ -1,5 +1,5 @@
-*! version 3.0.0  May 17 2022  statacons team
-* Copyright 2022. This work is licensed under a CC BY 4.0 license.
+*! version 3.0.1  Apr 13 2023  statacons team
+* Copyright 2023. This work is licensed under a CC BY 4.0 license.
 version 16.1
 
 // markdown source for help file is embedded below code


### PR DESCRIPTION
I've been working with @jethaaly on using `complete_datasignature.ado` and we noticed an unexpected behavior: it did not always return the same datasignature after saving and reopening the same file. Some debugging led us to the realization that Stata does not consistently store/read dataset `char`s in the same order. The changes in ordering were leading to changes in datasignature.

# Test Script

Here is a test script which passes using the version of `complete_datasignature.ado` included in this PR:

```
cscript "complete_datasignature" adofile complete_datasignature

clear all
set obs 1
gen x = 1

*----------------------------------------------------------------------------
* No dataset characteristics
*----------------------------------------------------------------------------

complete_datasignature, fast
local sig = r(signature)

*char list
tempfile chars0
save `chars0'

use `chars0'
complete_datasignature, fast
assert r(signature) == "`sig'"

*----------------------------------------------------------------------------
* One dataset characteristic
*----------------------------------------------------------------------------

char _dta[one] this is char named one of _dta

complete_datasignature, fast
local sig = r(signature)

*char list
tempfile chars1
save `chars1'

use `chars1'
*char list
complete_datasignature, fast
assert r(signature) == "`sig'"

*----------------------------------------------------------------------------
* Two dataset characteristics
*----------------------------------------------------------------------------

char _dta[two] this is char named two of _dta

complete_datasignature, fast
local sig = r(signature)

*char list
tempfile chars2
save `chars2'

use `chars2'
*char list
complete_datasignature, fast
assert r(signature) == "`sig'"

*----------------------------------------------------------------------------
* Real world example: auto.dta
*----------------------------------------------------------------------------

sysuse auto

complete_datasignature, fast
local sig = r(signature)

*char list
tempfile auto
save `auto'

use `auto'
*char list
complete_datasignature, fast
assert r(signature) == "`sig'"
```

# Failed Test

Here is the output of that test script when run using the published version 3.0.0 of `complete_datasignature`:

```
. cscript "complete_datasignature" adofile complete_datasignature
---------------------------------------------------BEGIN complete_datasignature

-> which complete_datasignature, usesysdir
./complete_datasignature.ado
*! version 3.0.0  May 17 2022  statacons team

. 
. clear all

. set obs 1
Number of observations (_N) was 0, now 1.

. gen x = 1

. 
. *----------------------------------------------------------------------------
. * No dataset characteristics
. *----------------------------------------------------------------------------
. 
. complete_datasignature, fast
1:1(41611):1062512974:1082179481:1585064951

. local sig = r(signature)

. 
. *char list
. tempfile chars0

. save `chars0'
file /var/folders/k_/2j0cz_016ts3khdhr6f0z1yh0000gn/T//S_12334.000001 saved
    as .dta format

. 
. use `chars0'

. complete_datasignature, fast
1:1(41611):1062512974:1082179481:1585064951

. assert r(signature) == "`sig'"

. 
. *----------------------------------------------------------------------------
. * One dataset characteristic
. *----------------------------------------------------------------------------
. 
. char _dta[one] this is char named one of _dta

. 
. complete_datasignature, fast
1:1(41611):1062512974:1082179481:1443011726

. local sig = r(signature)

. 
. *char list
. tempfile chars1

. save `chars1'
file /var/folders/k_/2j0cz_016ts3khdhr6f0z1yh0000gn/T//S_12334.000002 saved
    as .dta format

. 
. use `chars1'

. *char list
. complete_datasignature, fast
1:1(41611):1062512974:1082179481:1443011726

. assert r(signature) == "`sig'"

. 
. *----------------------------------------------------------------------------
. * Two dataset characteristics
. *----------------------------------------------------------------------------
. 
. char _dta[two] this is char named two of _dta

. 
. complete_datasignature, fast
1:1(41611):1062512974:1082179481:1003984423

. local sig = r(signature)

. 
. *char list
. tempfile chars2

. save `chars2'
file /var/folders/k_/2j0cz_016ts3khdhr6f0z1yh0000gn/T//S_12334.000003 saved
    as .dta format

. 
. use `chars2'

. *char list
. complete_datasignature, fast
1:1(41611):1062512974:1082179481:118068626

. assert r(signature) == "`sig'"
assertion is false
r(9);

.
. *----------------------------------------------------------------------------
. * Real world example: auto.dta
. *----------------------------------------------------------------------------
. 
. sysuse auto
(1978 automobile data)

. 
. complete_datasignature, fast
74:12(71728):3831085005:186045760:3824887947

. local sig = r(signature)

. 
. *char list
. tempfile auto

. save `auto'
file /var/folders/k_/2j0cz_016ts3khdhr6f0z1yh0000gn/T//S_12334.000001 saved
    as .dta format

. 
. use `auto'
(1978 automobile data)

. *char list
. complete_datasignature, fast
74:12(71728):3831085005:186045760:721951946

. assert r(signature) == "`sig'"
assertion is false
r(9);
```